### PR TITLE
エラースタイルの変更

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,5 +26,5 @@ fn main() {
 }
 
 fn print_error(error: Error) {
-    println!("{}", error.to_string().red().bold())
+    println!("{}: {}", "error".red().bold(), error)
 }


### PR DESCRIPTION
エラーが全文赤色なのはイケてないなと思い修正
errorプレフィックスを赤で出して、メッセージを出すようにしたらどうかと思った

###before
<img width="601" alt="2019-01-21 21 48 17" src="https://user-images.githubusercontent.com/23740172/51475660-6a8f0a00-1dc6-11e9-94f6-093b813d53b7.png">

###after
<img width="517" alt="2019-01-21 21 48 02" src="https://user-images.githubusercontent.com/23740172/51475666-6e229100-1dc6-11e9-97c6-61626668d347.png">
