### PR TITLE
docs: Replace with new email address

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at contact@student-kyushu.org. All
+reported by contacting the project team at contact@kyushu.gr.jp. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,10 +64,10 @@ Recommend to use these:
 
 ## Issues
 
-If you find a security vulnerability, do **NOT** open an issue. Email contact@student-kyushu.org instead.
+If you find a security vulnerability, do **NOT** open an issue. Email contact@kyushu.gr.jp instead.
 
 Feature requests and bug reports are filed in https://github.com/student-kyushu/hibana/issues. Before submitting a new issue, please search for similar issues. If somebody has encountered similar bug or wanted similar feature, please add your reaction or comment to the issues.💓
 
 ## Community
 
-Hibana is developed with the support and involvement of KSA. If you're interested in us, please visit https://student-kyushu.org.
+Hibana is developed with the support and involvement of KSA. If you're interested in us, please visit https://kyushu.gr.jp.


### PR DESCRIPTION
### Types of this PR

<!-- Check one of the following -->

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Test
- [ ] Refactor

### Description

We have and use kyushu.gr.jp instead of student-kyushu.org now.

