### PR TITLE
Install rustfmt with cargo instead of rustup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run:
           name: Check code format
           command: |
-            rustup component add rustfmt-preview
+            cargo install rustfmt-nightly --force
             rustfmt --version
             cargo fmt
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
 before_install:
   - set -e
   - rustup self update
-  - rustup component add rustfmt-preview
+  - cargo install rustfmt-nightly --force
 script:
   - cargo fmt
   - cargo build --verbose --all


### PR DESCRIPTION
### Types of this PR

<!-- Check one of the following -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Test
- [ ] Refactor

### Description
`rustup component install rustfmt-preview` is unstable.
`cargo install rustfmt-nightly` is recommended.

### Related Issue (if any)

None
